### PR TITLE
Fix tracking link to omit port 8443

### DIFF
--- a/core/internal/service/domains/baseurl.go
+++ b/core/internal/service/domains/baseurl.go
@@ -96,7 +96,7 @@ func buildBaseURL(hostname string) (s string) {
 
 	withPort := true
 
-	if serverPort == -1 || serverPort == 80 || serverPort == 443 {
+	if serverPort == -1 || serverPort == 80 || serverPort == 443 || serverPort == 8443 {
 		withPort = false
 	}
 


### PR DESCRIPTION
## Summary
- avoid including port 8443 in tracking URLs by updating `buildBaseURL`

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68663bd39a68832b9df7274d70d40963